### PR TITLE
Solve #127 Hotfix Adicionar CNPJ na APU de notas

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Abra outro terminal, e execute o comando:
 
 
 ```
-docker-compose -f docker-compose-dev.yml run base python manage.py recreate_db
+docker-compose -f docker-compose-dev.yml run base python manage.py recreatedb
 ```
 
 

--- a/manage.py
+++ b/manage.py
@@ -19,7 +19,7 @@ cli = FlaskGroup(app)
 
 # Create command
 @cli.command()
-def recreate_db():
+def recreatedb():
     db.drop_all()
     db.create_all()
     db.session.commit()

--- a/project/api/models.py
+++ b/project/api/models.py
@@ -10,13 +10,15 @@ class Receipt(db.Model):
     company_id     = db.Column(db.Integer,  nullable=False)
     emission_date  = db.Column(db.DateTime, nullable=False)
     emission_place = db.Column(db.String(128), nullable=False)
+    cnpj           = db.Column(db.String, nullable=False)
     tax_value      = db.Column(db.Float,    nullable=False)
     total_price    = db.Column(db.Float,    nullable=False)
 
-    def __init__(self, company_id, emission_date, emission_place, tax_value, total_price):
+    def __init__(self, company_id, emission_date, emission_place, cnpj, tax_value, total_price):
         self.company_id     = company_id 
         self.emission_date  = emission_date 
-        self.emission_place = emission_place 
+        self.emission_place = emission_place
+        self.cnpj           = cnpj
         self.tax_value      = tax_value 
         self.total_price    = total_price 
 
@@ -26,6 +28,7 @@ class Receipt(db.Model):
             'company_id': self.company_id,
             'emission_date': self.emission_date.date().isoformat(),
             'emission_place': self.emission_place,
+            'cnpj': self.cnpj,
             'tax_value': self.tax_value,
             'total_price': self.total_price
         }

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -37,6 +37,7 @@ def add_receipt():
     company_id = receipt.get('company_id')
     emission_date = receipt.get('emission_date')
     emission_place = receipt.get('emission_place')
+    cnpj = receipt.get('cnpj')
     tax_value = receipt.get('tax_value')
     total_price = receipt.get('total_price')
 
@@ -46,7 +47,7 @@ def add_receipt():
         return jsonify(error_response), 400
     
     try:
-        receipt = Receipt(company_id, emission_date, emission_place, tax_value, total_price)
+        receipt = Receipt(company_id, emission_date, emission_place, cnpj, tax_value, total_price)
         db.session.add(receipt)
         db.session.flush()
 

--- a/project/tests/test_receipts.py
+++ b/project/tests/test_receipts.py
@@ -7,8 +7,8 @@ from project import db
 
 
 
-def add_receipt(company_id, emission_date, emission_place, tax_value, total_price):
-    receipt = Receipt(company_id, emission_date, emission_place, tax_value, total_price)
+def add_receipt(company_id, emission_date, emission_place, cnpj, tax_value, total_price):
+    receipt = Receipt(company_id, emission_date, emission_place, cnpj, tax_value, total_price)
     db.session.add(receipt)
     db.session.commit()
     return receipt
@@ -18,8 +18,8 @@ class TestReceiptservice(BaseTestCase):
         date_text = "22-09-2018"
         date = datetime.strptime(date_text, '%d-%m-%Y').date()
 
-        add_receipt(15, date, "GitHub", 20.0, 50.0)
-        add_receipt(16, date, "Gitlab", 15.0, 20.0)
+        add_receipt(15, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0)
+        add_receipt(16, date, "Gitlab", "00.000.000/0000-00", 15.0, 20.0)
 
         with self.client:
             response = self.client.get('/receipts')
@@ -33,12 +33,14 @@ class TestReceiptservice(BaseTestCase):
             self.assertEqual(15, data['data']['receipt'][0]['company_id'])
             self.assertEqual(date.isoformat(), data['data']['receipt'][0]['emission_date'])
             self.assertIn('GitHub', data['data']['receipt'][0]['emission_place'])
+            self.assertIn('00.000.000/0000-00', data['data']['receipt'][0]['cnpj'])
             self.assertEqual(20.0, data['data']['receipt'][0]['tax_value'])
             self.assertEqual(50.0, data['data']['receipt'][0]['total_price'])
 
             self.assertEqual(16, data['data']['receipt'][1]['company_id'])
             self.assertEqual(date.isoformat(), data['data']['receipt'][1]['emission_date'])
             self.assertIn('Gitlab', data['data']['receipt'][1]['emission_place'])
+            self.assertIn('00.000.000/0000-00', data['data']['receipt'][1]['cnpj'])
             self.assertEqual(15.0, data['data']['receipt'][1]['tax_value'])
             self.assertEqual(20.0, data['data']['receipt'][1]['total_price'])
 
@@ -56,6 +58,7 @@ class TestReceiptservice(BaseTestCase):
                         'company_id': '1234',
                         'emission_date': date.isoformat(),
                         'emission_place': 'place',
+                        'cnpj': '00.000.000/0000-00',
                         'tax_value': '123.12',
                         'total_price': '456.45',
                         'products':[
@@ -99,6 +102,7 @@ class TestReceiptservice(BaseTestCase):
                     'receipt':{
                         'emission_date': date.isoformat(),
                         'emission_place': 'place',
+                        'cnpj': '00.000.000/0000-00',
                         'tax_value': '123.12',
                         'total_price': '456.45',
                         'products':[
@@ -124,6 +128,7 @@ class TestReceiptservice(BaseTestCase):
                     'receipt':{
                         'company_id': '1234',
                         'emission_place': 'place',
+                        'cnpj': '00.000.000/0000-00',
                         'tax_value': '123.12',
                         'total_price': '456.45',
                         'products':[
@@ -153,6 +158,37 @@ class TestReceiptservice(BaseTestCase):
                     'receipt':{
                         'company_id': '1234',
                         'emission_date': date.isoformat(),
+                        'cnpj': '00.000.000/0000-00',
+                        'tax_value': '123.12',
+                        'total_price': '456.45',
+                        'products':[
+                            {'quantity': 2, 'unit_price': 13.12},
+                            {'quantity': 1, 'unit_price': 12.13}
+                        ]
+                    }
+                }),
+                content_type='application/json',
+            )
+            
+            data = json.loads(response.data.decode())
+
+            self.assertEqual(response.status_code, 400)
+            self.assertIn('wrong json', data['message'])
+            self.assertIn('fail', data['status'])
+
+    def test_add_task_missing_cnpj(self):
+
+        date_text = "22-09-2018"
+        date = datetime.strptime(date_text, '%d-%m-%Y').date()
+
+        with self.client:
+            response = self.client.post(
+                '/receipt',
+                data = json.dumps({
+                    'receipt':{
+                        'company_id': '1234',
+                        'emission_date': date.isoformat(),
+                        'emission_place': 'place',
                         'tax_value': '123.12',
                         'total_price': '456.45',
                         'products':[
@@ -183,6 +219,7 @@ class TestReceiptservice(BaseTestCase):
                         'company_id': '1234',
                         'emission_date': date.isoformat(),
                         'emission_place': 'place',
+                        'cnpj': '00.000.000/0000-00',
                         'total_price': '456.45',
                         'products':[
                             {'quantity': 2, 'unit_price': 13.12},
@@ -212,6 +249,7 @@ class TestReceiptservice(BaseTestCase):
                         'company_id': '1234',
                         'emission_date': date.isoformat(),
                         'emission_place': 'place',
+                        'cnpj': '00.000.000/0000-00',
                         'tax_value': '123.12',
                         'products':[
                             {'quantity': 2, 'unit_price': 13.12},
@@ -242,6 +280,7 @@ class TestReceiptservice(BaseTestCase):
                         'company_id': '1234',
                         'emission_date': date.isoformat(),
                         'emission_place': 'place',
+                        'cnpj': '00.000.000/0000-00',
                         'tax_value': '123.12',
                         'total_price': '456.45'
                     }
@@ -268,6 +307,7 @@ class TestReceiptservice(BaseTestCase):
                         'company_id': '1234',
                         'emission_date': date.isoformat(),
                         'emission_place': 'place',
+                        'cnpj': '00.000.000/0000-00',
                         'tax_value': '123.12',
                         'total_price': '456.45',
                         'products':[
@@ -299,6 +339,7 @@ class TestReceiptservice(BaseTestCase):
                         'company_id': '1234',
                         'emission_date': date.isoformat(),
                         'emission_place': 'place',
+                        'cnpj': '00.000.000/0000-00',
                         'tax_value': '123.12',
                         'total_price': '456.45',
                         'products':[
@@ -319,7 +360,7 @@ class TestReceiptservice(BaseTestCase):
     def test_get_single_receipt(self):
         date_text = "22-09-2018"
         date = datetime.strptime(date_text, '%d-%m-%Y').date() 
-        receipt = add_receipt(15, date, "GitHub", 20.0, 50.0)
+        receipt = add_receipt(15, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0)
 
         with self.client:
             response = self.client.get(f'/receipt/{receipt.id}')
@@ -331,6 +372,7 @@ class TestReceiptservice(BaseTestCase):
             self.assertEqual(15, data['data']['company_id'])
             self.assertEqual(date.isoformat(), data['data']['emission_date'])
             self.assertIn('GitHub', data['data']['emission_place'])
+            self.assertIn('00.000.000/0000-00', data['data']['cnpj'])
             self.assertEqual(20.0, data['data']['tax_value'])
             self.assertEqual(50.0, data['data']['total_price'])
 


### PR DESCRIPTION
Neste pull request se realizou:
  * Hotfix
  * Correção do RecreateDB
  * Adição do CNPJ na views e na Models
  * Adição de testes no CNPJ