### PR TITLE
Solve #205 Associar Notas à Empresa

### DIFF
--- a/project/api/models.py
+++ b/project/api/models.py
@@ -69,16 +69,19 @@ class Product(db.Model):
 class Tag(db.Model):
     __tablename__ = 'tag'
     id         = db.Column(db.Integer,  primary_key=True, autoincrement=True)
+    company_id     = db.Column(db.Integer,     nullable=False)
     category   = db.Column(db.String(50), nullable=False)
     color      = db.Column(db.String(50), nullable=True)
 
-    def __init__(self, category, color):
+    def __init__(self, category, company_id, color):
         self.category = category
+        self.company_id = company_id
         self.color = color
     
     def to_json(self):
         return {
             'id': self.id,
+            'company_id': self.company_id,
             'category': self.category,
             'color': self.color
         } 

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -157,12 +157,12 @@ def delete_receipt(company_id, receipt_id):
     return jsonify(response), 200
 
 
-@receipts_blueprint.route('/tags', methods=['GET'])
-def get_all_tags(): 
+@receipts_blueprint.route('/<company_id>/tags', methods=['GET'])
+def get_all_tags(company_id): 
     response = {
         'status': 'success',
         'data': {
-            'tags': [tag.to_json() for tag in Tag.query.all()]
+            'tags': [tag.to_json() for tag in Tag.query.filter_by(company_id=int(company_id))]
         }
     }
     return jsonify(response), 200
@@ -236,8 +236,9 @@ def create_tag():
     if not color:
         return jsonify(error_response_missing_color), 400
 
-    check_tag = []
-    for check_tag in Tag.query.all():
+    company_id = tag.get('company_id')
+
+    for check_tag in Tag.query.filter_by(company_id=tag.get('company_id')):
         if category == check_tag.to_json().get('category'):
             return jsonify({
                 'status': 'fail',
@@ -245,7 +246,7 @@ def create_tag():
             }), 409
 
     try:
-        tag = Tag(category, color)
+        tag = Tag(category, company_id, color)
         db.session.add(tag)
         db.session.commit()
 

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -76,14 +76,14 @@ def add_receipt():
 
 
 
-@receipts_blueprint.route('/receipt/<receipt_id>', methods=['GET'])
-def get_single_receipt(receipt_id):
+@receipts_blueprint.route('/<company_id>/receipt/<receipt_id>', methods=['GET'])
+def get_single_receipt(company_id, receipt_id):
     error_response = {
         'status': 'fail',
         'message': 'Receipt not found'
     }
     try:
-        receipt = Receipt.query.filter_by(id=int(receipt_id)).first()
+        receipt = Receipt.query.filter_by(id=int(receipt_id), company_id=int(company_id)).first()
 
         if not receipt:
             return jsonify(error_response), 404

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -132,26 +132,27 @@ def filter_date(company_id):
 
     return jsonify(response), 200
     
-@receipts_blueprint.route('/receipt/<receipt_id>', methods=['DELETE'])
-def delete_receipt(receipt_id):
+@receipts_blueprint.route('/<company_id>/receipt/<receipt_id>', methods=['DELETE'])
+def delete_receipt(company_id, receipt_id):
     error_response = {
         'status': 'fail',
         'message': 'Receipt not found'
     }
-    try:
-        receipt = Receipt.query.filter_by(id=int(receipt_id)).first()
-        db.session.delete(receipt)
-        db.session.commit()
 
-        response = {
-            'status': 'success',
-            'data': {
-                'message': 'Receipt deleted'
-            }
-        }
+    receipt = Receipt.query.filter_by(id=int(receipt_id), company_id=int(company_id)).first()
 
-    except ValueError:
+    if not receipt:
         return jsonify(error_response), 404
+
+    db.session.delete(receipt)
+    db.session.commit()
+
+    response = {
+        'status': 'success',
+        'data': {
+            'message': 'Receipt deleted'
+        }
+    }
 
     return jsonify(response), 200
 

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -11,12 +11,12 @@ from project import db
 receipts_blueprint = Blueprint('receipt', __name__)
 
 
-@receipts_blueprint.route('/receipts', methods=['GET'])
-def get_all_receipts():
+@receipts_blueprint.route('/<company_id>/receipts', methods=['GET'])
+def get_all_receipts(company_id):
     response = {
         'status': 'success',
         'data': {
-            'receipts': [receipt.to_json() for receipt in Receipt.query.all()]
+            'receipts': [receipt.to_json() for receipt in Receipt.query.filter_by(company_id=int(company_id))]
         }
     }
     return jsonify(response), 200

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -97,8 +97,8 @@ def get_single_receipt(company_id, receipt_id):
 
     return jsonify(response), 200
 
-@receipts_blueprint.route('/select_date', methods=['POST'])
-def filter_date():
+@receipts_blueprint.route('/<company_id>/select_date', methods=['POST'])
+def filter_date(company_id):
     post_data_date = request.get_json()
 
     error_response = {
@@ -122,7 +122,7 @@ def filter_date():
 
     
     response = {
-        'receipts': [receipt.to_json() for receipt in Receipt.query.filter(Receipt.emission_date <= end).filter(Receipt.emission_date >= start)]
+        'receipts': [receipt.to_json() for receipt in Receipt.query.filter(Receipt.emission_date <= end).filter(Receipt.emission_date >= start).filter(Receipt.company_id == int(company_id))]
     }
 
     if not response.get('receipts'):

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -167,13 +167,21 @@ def get_all_tags():
     }
     return jsonify(response), 200
 
-@receipts_blueprint.route('/update_tag/<receipt_id>', methods=['PATCH'])
-def update_tag(receipt_id):
+@receipts_blueprint.route('/<company_id>/update_tag/<receipt_id>', methods=['PATCH'])
+def update_tag(company_id, receipt_id):
     post_data = request.get_json()
 
     tag_id = post_data.get('tag_id')
 
-    receipt = Receipt.query.filter_by(id=int(receipt_id)).first()
+    receipt = Receipt.query.filter_by(id=int(receipt_id), company_id=int(company_id)).first()
+    if not receipt:
+        error_response = {
+            'status': 'fail',
+            'message': 'Receipt not found'
+        }
+        return jsonify(error_response), 404
+
+
     receipt.tag_id = tag_id
     db.session.commit()
 

--- a/project/tests/test_receipts.py
+++ b/project/tests/test_receipts.py
@@ -414,7 +414,7 @@ class TestReceiptservice(BaseTestCase):
         receipt = add_receipt(15, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0, 'Geladeira', 'Geladeira Electrolux em 12x', None)
 
         with self.client:
-            response = self.client.get(f'/receipt/{receipt.id}')
+            response = self.client.get(f'/15/receipt/{receipt.id}')
             data = json.loads(response.data.decode())
 
             self.assertEqual(response.status_code, 200)
@@ -432,7 +432,7 @@ class TestReceiptservice(BaseTestCase):
 
     def test_get_single_receipt_no_id(self):
         with self.client:
-            response = self.client.get('/receipt/noid')
+            response = self.client.get('/2/receipt/noid')
             data = json.loads(response.data.decode())
             self.assertEqual(response.status_code, 404)
             self.assertIn('fail', data['status'])
@@ -440,7 +440,23 @@ class TestReceiptservice(BaseTestCase):
 
     def test_get_single_receipt_inexistent_id(self):
         with self.client:
-            response = self.client.get('/receipt/100000')
+            response = self.client.get('/1/receipt/100000')
+            data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 404)
+            self.assertIn('fail', data['status'])
+            self.assertIn('Receipt not found', data['message'])
+    
+    def test_get_single_receipt_no_companyid(self):
+        with self.client:
+            response = self.client.get('/noid/receipt/2')
+            data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 404)
+            self.assertIn('fail', data['status'])
+            self.assertIn('Receipt not found', data['message'])
+
+    def test_get_single_receipt_inexistent_id(self):
+        with self.client:
+            response = self.client.get('/1000000000/receipt/1')
             data = json.loads(response.data.decode())
             self.assertEqual(response.status_code, 404)
             self.assertIn('fail', data['status'])

--- a/project/tests/test_receipts.py
+++ b/project/tests/test_receipts.py
@@ -656,11 +656,11 @@ class TestReceiptservice(BaseTestCase):
             self.assertIn('Receipt not found', data['message'])
 
     def test_get_tags(self):
-        add_tag('Alimentação', "#874845")
-        add_tag('Eletrodoméstico', '#844155')
+        add_tag('Alimentação', 15, "#874845")
+        add_tag('Eletrodoméstico', 15, '#844155')
 
         with self.client:
-            response = self.client.get('/tags')
+            response = self.client.get('/15/tags')
             data = json.loads(response.data.decode())
 
             self.assertEqual(response.status_code, 200)
@@ -680,7 +680,7 @@ class TestReceiptservice(BaseTestCase):
 
         receipt = add_receipt(15, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0, "Geladeira", "Isso é uma descrição bem grande", None)
 
-        add_tag('Alimentação', '#844155')
+        add_tag('Alimentação', 15, '#844155')
 
         with self.client:
             response = self.client.patch(
@@ -703,7 +703,7 @@ class TestReceiptservice(BaseTestCase):
 
         receipt = add_receipt(16, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0, "Geladeira", "Isso é uma descrição bem grande", None)
 
-        add_tag('Alimentação', '#844155')
+        add_tag('Alimentação', 15, '#844155')
 
         with self.client:
             response = self.client.patch(
@@ -748,6 +748,7 @@ class TestReceiptservice(BaseTestCase):
                 data=json.dumps({
                     "tag": {
                         "color": "black",
+                        "company_id": 15,
                         "category": "Utilitários"
                     }
                 }),
@@ -774,15 +775,16 @@ class TestReceiptservice(BaseTestCase):
             self.assertIn('wrong json', data['message'])
             self.assertIn('fail', data['status'])
 
-    def test_category_was_exist_create_tag(self):
+    def test_category_already_exists_create_tag(self):
 
-        add_tag('Utilitários', 'black')
+        add_tag('Utilitários', 15, 'black')
         with self.client:
             response = self.client.post(
                 '/create_tag',
                 data=json.dumps({
                     "tag": {
                         "color": "black",
+                        "company_id": 15,
                         "category": "Utilitários"
                     }
                 }),

--- a/project/tests/test_receipts.py
+++ b/project/tests/test_receipts.py
@@ -17,11 +17,11 @@ class TestReceiptservice(BaseTestCase):
         add_receipt(16, date, "Gitlab", "00.000.000/0000-00", 15.0, 20.0, "Notebook", "Isso é outro description", None)
 
         with self.client:
-            response = self.client.get('/receipts')
+            response = self.client.get('/15/receipts')
             data = json.loads(response.data.decode())
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(data['data']['receipts']), 2)
+            self.assertEqual(len(data['data']['receipts']), 1)
 
             self.assertIn('success', data['status'])
 
@@ -34,16 +34,6 @@ class TestReceiptservice(BaseTestCase):
             self.assertIn('Geladeira', data['data']['receipts'][0]['title'])
             self.assertIn('Isso é uma descrição bem grande', data['data']['receipts'][0]['description'])
             self.assertEqual(None, data['data']['receipts'][0]['tag_id'])
-
-            self.assertEqual(16, data['data']['receipts'][1]['company_id'])
-            self.assertEqual(date.isoformat(), data['data']['receipts'][1]['emission_date'])
-            self.assertIn('Gitlab', data['data']['receipts'][1]['emission_place'])
-            self.assertIn('00.000.000/0000-00', data['data']['receipts'][1]['cnpj'])
-            self.assertEqual(15.0, data['data']['receipts'][1]['tax_value'])
-            self.assertEqual(20.0, data['data']['receipts'][1]['total_price'])
-            self.assertIn('Notebook', data['data']['receipts'][1]['title'])
-            self.assertIn('Isso é outro description', data['data']['receipts'][1]['description'])
-            self.assertEqual(None, data['data']['receipts'][1]['tag_id'])
 
     def test_add_receipt(self):
 

--- a/project/tests/test_receipts.py
+++ b/project/tests/test_receipts.py
@@ -684,7 +684,7 @@ class TestReceiptservice(BaseTestCase):
 
         with self.client:
             response = self.client.patch(
-                f'/update_tag/{receipt.id}',
+                f'/15/update_tag/{receipt.id}',
                 data = json.dumps({
                     'tag_id': 1
                 }),
@@ -697,6 +697,29 @@ class TestReceiptservice(BaseTestCase):
             self.assertIn('Tag updated!', data['data']['message'])
             self.assertIn('success', data['status'])
 
+    def test_update_tag_not_found(self):
+        date_text = "22-09-2018"
+        date = datetime.strptime(date_text, '%d-%m-%Y').date()
+
+        receipt = add_receipt(16, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0, "Geladeira", "Isso é uma descrição bem grande", None)
+
+        add_tag('Alimentação', '#844155')
+
+        with self.client:
+            response = self.client.patch(
+                f'/15/update_tag/{receipt.id}',
+                data = json.dumps({
+                    'tag_id': 1
+                }),
+                content_type='application/json'
+            )
+
+            data = json.loads(response.data.decode())
+
+            self.assertEqual(response.status_code, 404)
+            self.assertIn('Receipt not found', data['message'])
+            self.assertIn('fail', data['status'])
+
     def test_detach_tag(self):
         date_text = "22-09-2018"
         date = datetime.strptime(date_text, '%d-%m-%Y').date()
@@ -705,7 +728,7 @@ class TestReceiptservice(BaseTestCase):
 
         with self.client:
             response = self.client.patch(
-                f'/update_tag/{receipt.id}',
+                f'/15/update_tag/{receipt.id}',
                 data = json.dumps({
                     'tag_id': None
                 }),

--- a/project/tests/test_receipts.py
+++ b/project/tests/test_receipts.py
@@ -634,12 +634,26 @@ class TestReceiptservice(BaseTestCase):
         receipt = add_receipt(15, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0, 'Geladeira', 'Geladeira Electrolux em 12x', None)
 
         with self.client:
-            response = self.client.delete(f'/receipt/{receipt.id}')
+            response = self.client.delete(f'/15/receipt/{receipt.id}')
             data = json.loads(response.data.decode())
             
             self.assertEqual(response.status_code, 200)
             self.assertIn('success', data['status'])
             self.assertIn('Receipt deleted', data['data']['message'])
+
+    def test_remove_receipt_not_found(self):
+        date_text = "22-09-2018"
+        date = datetime.strptime(date_text, '%d-%m-%Y').date()
+
+        receipt = add_receipt(16, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0, 'Geladeira', 'Geladeira Electrolux em 12x', None)
+
+        with self.client:
+            response = self.client.delete(f'/15/receipt/{receipt.id}')
+            data = json.loads(response.data.decode())
+
+            self.assertEqual(response.status_code, 404)
+            self.assertIn('fail', data['status'])
+            self.assertIn('Receipt not found', data['message'])
 
     def test_get_tags(self):
         add_tag('Alimentação', "#874845")

--- a/project/tests/test_receipts.py
+++ b/project/tests/test_receipts.py
@@ -478,7 +478,7 @@ class TestReceiptservice(BaseTestCase):
         with self.client:
 
             response = self.client.post(
-                '/select_date',
+                '/15/select_date',
                 data = json.dumps({
                     "period": {
                         "date_from": start.isoformat(),
@@ -500,18 +500,7 @@ class TestReceiptservice(BaseTestCase):
             self.assertEqual(50.0, data['receipts'][0]['total_price'])
             self.assertIn('Geladeira', data['receipts'][0]['title'])
             self.assertIn('Isso é uma descrição bem grande', data['receipts'][0]['description'])
-            self.assertEqual(None, data['receipts'][0]['tag_id'])
-
-            self.assertEqual(16, data['receipts'][1]['company_id'])
-            self.assertEqual(date.isoformat(), data['receipts'][1]['emission_date'])
-            self.assertIn('Gitlab', data['receipts'][1]['emission_place'])
-            self.assertIn('00.000.000/0000-00', data['receipts'][1]['cnpj'])
-            self.assertEqual(15.0, data['receipts'][1]['tax_value'])
-            self.assertEqual(20.0, data['receipts'][1]['total_price'])
-            self.assertIn('Notebook', data['receipts'][1]['title'])
-            self.assertIn('Isso é outro description', data['receipts'][1]['description'])
-            self.assertEqual(None, data['receipts'][1]['tag_id'])
-            
+            self.assertEqual(None, data['receipts'][0]['tag_id'])            
 
     def test_filter_date_no_receipts(self):
         date_from = "22-07-1900"
@@ -528,7 +517,7 @@ class TestReceiptservice(BaseTestCase):
         with self.client:
 
             response = self.client.post(
-                '/select_date',
+                '/15/select_date',
                 data = json.dumps({
                     "period": {
                         "date_from": start.isoformat(),
@@ -551,13 +540,13 @@ class TestReceiptservice(BaseTestCase):
         date = datetime.strptime(date_text, '%d-%m-%Y').date()
 
         add_receipt(15, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0, "Geladeira", "Isso é uma descrição bem grande", None)
-        add_receipt(16, date, "Gitlab", "00.000.000/0000-00", 15.0, 20.0, "Notebook", "Isso é outro description", None)
+        add_receipt(15, date, "Gitlab", "00.000.000/0000-00", 15.0, 20.0, "Notebook", "Isso é outro description", None)
 
 
         with self.client:
 
             response = self.client.post(
-                '/select_date',
+                '/15/select_date',
                 data = json.dumps({
                     "period": {
                         "date_to": end.isoformat()
@@ -580,7 +569,7 @@ class TestReceiptservice(BaseTestCase):
             self.assertIn('Isso é uma descrição bem grande', data['receipts'][0]['description'])
             self.assertEqual(None, data['receipts'][0]['tag_id'])
 
-            self.assertEqual(16, data['receipts'][1]['company_id'])
+            self.assertEqual(15, data['receipts'][1]['company_id'])
             self.assertEqual(date.isoformat(), data['receipts'][1]['emission_date'])
             self.assertIn('Gitlab', data['receipts'][1]['emission_place'])
             self.assertIn('00.000.000/0000-00', data['receipts'][1]['cnpj'])
@@ -599,13 +588,13 @@ class TestReceiptservice(BaseTestCase):
         date = datetime.strptime(date_text, '%d-%m-%Y').date()
 
         add_receipt(15, date, "GitHub", "00.000.000/0000-00", 20.0, 50.0, "Geladeira", "Isso é uma descrição bem grande", None)
-        add_receipt(16, date, "Gitlab", "00.000.000/0000-00", 15.0, 20.0, "Notebook", "Isso é outro description", None)
+        add_receipt(15, date, "Gitlab", "00.000.000/0000-00", 15.0, 20.0, "Notebook", "Isso é outro description", None)
 
 
         with self.client:
 
             response = self.client.post(
-                '/select_date',
+                '/15/select_date',
                 data = json.dumps({
                     "period": {
                         "date_from": start.isoformat()
@@ -628,7 +617,7 @@ class TestReceiptservice(BaseTestCase):
             self.assertIn('Isso é uma descrição bem grande', data['receipts'][0]['description'])
             self.assertEqual(None, data['receipts'][0]['tag_id'])
 
-            self.assertEqual(16, data['receipts'][1]['company_id'])
+            self.assertEqual(15, data['receipts'][1]['company_id'])
             self.assertEqual(date.isoformat(), data['receipts'][1]['emission_date'])
             self.assertIn('Gitlab', data['receipts'][1]['emission_place'])
             self.assertIn('00.000.000/0000-00', data['receipts'][1]['cnpj'])

--- a/project/tests/utils.py
+++ b/project/tests/utils.py
@@ -7,8 +7,8 @@ def add_receipt(company_id, emission_date, emission_place, cnpj, tax_value, tota
     db.session.commit()
     return receipt
 
-def add_tag(category, color):
-    tag = Tag(category, color)
+def add_tag(category, company_id, color):
+    tag = Tag(category, company_id, color)
     db.session.add(tag)
     db.session.commit()
     return tag


### PR DESCRIPTION
Neste pull request se realizou:

* [US36 - Associar Notas à Empresa](https://github.com/fga-eps-mds/2018.2-Kalkuli/issues/205)
  * Adaptação dos _endpoints_ de receipts, e tags para terem seu escopo restringido à empresa do usuário acessando a aplicação.